### PR TITLE
[WIP] Bugfix upload performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/react-virtualized": "^9.21.2",
     "moment": "^2.22.2",
     "react": "^16.6.1",
     "react-dom": "^16.6.1",
@@ -10,6 +11,7 @@
     "react-moment": "^0.8.3",
     "react-router-dom": "^4.3.1",
     "react-scripts-ts": "3.1.0",
+    "react-virtualized": "^9.21.1",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.83.0",
     "uuid": "^3.3.2"

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,15 @@
 /*.App {
     margin: 20px;
 }*/
-
+.ReactVirtualized__Table__headerColumn{
+	display:inline-block;
+	width:150px;
+	border:1px solid black;
+}
+.ReactVirtualized__Table__rowColumn{
+	display:inline-block;
+	width:150px;
+}
 .ui.container.container-position{
 	margin-left:15rem !important;
 	margin-top:20px;

--- a/src/components/DropUpload.tsx
+++ b/src/components/DropUpload.tsx
@@ -64,14 +64,14 @@ export interface IDropUploadState {
     isLoading: boolean;
     uploadModalOpen: boolean;
     acceptedFileTypes: IAcceptedFileTypes;
-} 
+}
 
 // tslint:disable-next-line:max-classes-per-file
 class DropUpload extends React.Component<any, IDropUploadState> {
     constructor(props: any) {
         super(props);
         this.state = {
-            acceptedFileTypes: {audio: [], transcription: []} as IAcceptedFileTypes,
+            acceptedFileTypes: { audio: [], transcription: [] } as IAcceptedFileTypes,
             dragActive: false,
             formLoading: false,
             isLoading: true,
@@ -89,7 +89,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
     }
 
     public getData() {
-        this.setState({isLoading: true});
+        this.setState({ isLoading: true });
         api.persephoneApiApiEndpointsBackendAcceptedFiletypes().then(res => res.json()).then(json => {
             this.setState({
                 acceptedFileTypes: json as IAcceptedFileTypes,
@@ -103,7 +103,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
     }
 
     public onDragEnter() {
-        this.setState({dragActive: true})
+        this.setState({ dragActive: true })
     }
 
     public match() {
@@ -135,16 +135,16 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                     utteranceInfo
                 }
                 api.utterancePost(requestData).then(res => {
-                    this.setState({matches: this.state.matches.map(m => m.id === id ? {...m, state: RequestState.COMPLETE} : m)})
+                    this.setState({ matches: this.state.matches.map(m => m.id === id ? { ...m, state: RequestState.COMPLETE } : m) })
                 }).catch(err => {
-                    this.setState({matches: this.state.matches.map(m => m.id === id ? {...m, state: RequestState.FAILED} : m)})
+                    this.setState({ matches: this.state.matches.map(m => m.id === id ? { ...m, state: RequestState.FAILED } : m) })
                 });
             }
         }
         this.setState({
             matches: this.state.matches.concat(newMatches),
-            uploadedFiles: this.state.uploadedFiles.map(f => ({...f, matched: f.matched || matchedIds.indexOf(f.id) > -1}))
-        })
+            uploadedFiles: this.state.uploadedFiles.map(f => ({ ...f, matched: f.matched || matchedIds.indexOf(f.id) > -1 }))
+        })  
     }
 
     public updateFile(id: string, file: Partial<IUploadedFile<any>>) {
@@ -197,10 +197,12 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                         audioFile: file
                     }
                     api.audioPost(requestData).then(res => {
-                        this.updateFile(id, {state: RequestState.COMPLETE, fileT: res})
+                        this.updateFile(id, { state: RequestState.COMPLETE, fileT: res })
+                        console.log("audio id: ", res.id)
+                        // console.log("audiofileid: ", res.fileInfo.id)
                         console.log("successfully uploaded", file)
                     }).catch(err => {
-                        this.updateFile(id, {state: RequestState.FAILED})
+                        this.updateFile(id, { state: RequestState.FAILED })
                     });
                 } else if (this.state.acceptedFileTypes.transcription.indexOf(extension) > -1) {
                     uploadedFiles.push({
@@ -217,10 +219,12 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                         transcriptionFile: file
                     }
                     api.persephoneApiApiEndpointsTranscriptionFromFile(requestData).then(res => {
-                        this.updateFile(id, {state: RequestState.COMPLETE, fileT: res})
+                        this.updateFile(id, { state: RequestState.COMPLETE, fileT: res })
+                        console.log("transcription id", res.id)
+                        // console.log("transcriptionfile id", res.fileInfo.id)
                         console.log("successfully uploaded", file)
                     }).catch(err => {
-                        this.updateFile(id, {state: RequestState.FAILED})
+                        this.updateFile(id, { state: RequestState.FAILED })
                     });
                 } else {
                     console.log("unknown filetype, not uploaded")
@@ -243,16 +247,18 @@ class DropUpload extends React.Component<any, IDropUploadState> {
             isLoading: false,
             uploadedFiles: this.state.uploadedFiles.concat(uploadedFiles)
         })
+        console.log('matches', this.state.matches)
+        console.log('uploadedFiles', this.state.uploadedFiles)
     }
 
     public onDragLeave() {
-        this.setState({dragActive: false})
+        this.setState({ dragActive: false })
     }
 
-    noRowsRenderer () {
+    noRowsRenderer() {
         return (
-          <div>
-            This table is empty
+            <div>
+                This table is empty
           </div>
         )
     }
@@ -261,7 +267,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
         return (
             <div>
                 <Header as='h1'>Drag 'n' drop upload</Header>
-                <Dropzone style={{position: "relative"}} onDrop={this.onDrop} onDragEnter={this.onDragEnter} onDragLeave={this.onDragLeave}>
+                <Dropzone style={{ position: "relative" }} onDrop={this.onDrop} onDragEnter={this.onDragEnter} onDragLeave={this.onDragLeave}>
                     <Segment placeholder={true} tertiary={this.state.dragActive} loading={this.state.isLoading}>
                         <Header icon={true}>
                             <Icon name='cloud upload' />
@@ -273,10 +279,70 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                 </Dropzone>
                 <Header as='h2'>Uploaded files</Header>
                 {this.state.uploadedFiles.length > 0 &&
-                    <p>{this.state.uploadedFiles.filter(f => f.fileType === 'Audio').length} audios found, 
-                    {this.state.uploadedFiles.filter(f => f.fileType === 'Transcription').length} transcriptions found, 
-                    {this.state.uploadedFiles.filter(f => f.matched === true).length/2} matches found, 
-                    {this.state.uploadedFiles.filter(f => f.fileType === 'Unknown').length} unknown files have not been uploaded</p>}
+                    <p>{this.state.uploadedFiles.filter(f => f.fileType === 'Audio').length} audios found, {this.state.uploadedFiles.filter(f => f.fileType === 'Transcription').length} transcriptions found, {this.state.uploadedFiles.filter(f => f.matched === true).length / 2} matches found, {this.state.uploadedFiles.filter(f => f.fileType === 'Unknown').length} unknown files have not been uploaded</p>}
+                <AutoSizer disableHeight={true}>
+                    {({ width }) => (
+                        <VTable
+                            headerHeight={30}
+                            height={250}
+                            noRowsRenderer={this.noRowsRenderer}
+                            rowCount={this.state.matches.length}
+                            rowGetter={({ index }) => this.state.matches[index]}
+                            rowHeight={40}
+                            width={width} >
+                            <Column
+                                label='Match'
+                                dataKey='state'
+                                width={100}
+                                cellRenderer={({ rowData }) => (
+                                    rowData === RequestState.FAILED ?
+                                        <Icon name="times" />
+                                        : rowData === RequestState.COMPLETE ?
+                                            <Icon name="check" />
+                                            : <Icon name="circle notch" loading={true} />
+                                )} />
+                            <Column
+                                label='Type'
+                                dataKey='audio | transcription'
+                                width={100}
+                                cellRenderer={({ rowData }) => (
+                                    rowData.fileType
+                                )} />
+                            <Column
+                                label='Upload state'
+                                dataKey='state'
+                                width={100} />
+                            <Column
+                                label='File name'
+                                dataKey='audio'
+                                width={300}
+                                cellRenderer={({ rowData }) => (
+                                    rowData.name
+                                )} />
+                            <Column
+                                label='ID'
+                                dataKey='audio'
+                                width={100}
+                                cellRenderer={({ rowData }) => (
+                                    rowData.fileT.id
+                                )} />
+                            <Column
+                                label='File ID'
+                                dataKey='audio'
+                                width={100}
+                                cellRenderer={({ rowData }) => (
+                                    rowData.fileT.fileInfo.id
+                                )} />
+                            <Column
+                                label='File created at'
+                                dataKey='audio'
+                                width={200}
+                                cellRenderer={({ rowData }) => (
+                                    <Time time={rowData.fileT.fileInfo.createdAt} />
+                                )} />
+                        </VTable>
+                    )}
+                </AutoSizer>
                 <AutoSizer disableHeight={true}>
                     {({ width }) => (
                         <VTable
@@ -284,16 +350,16 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                             height={250}
                             noRowsRenderer={this.noRowsRenderer}
                             rowCount={this.state.uploadedFiles.length}
-                            rowGetter={({index}) => this.state.uploadedFiles[index]}
+                            rowGetter={({ index }) => this.state.uploadedFiles[index]}
                             rowHeight={40}
                             width={width} >
                             <Column
                                 label='Match'
-                                dataKey='state'
-                                width={100} 
+                                dataKey='matched'
+                                width={100}
                                 cellRenderer={({ rowData }) => (
                                     rowData ? <Icon name="check" />
-                                    : <Icon name="question" />
+                                        : <Icon name="question" />
                                 )} />
                             <Column
                                 label='Type'
@@ -313,19 +379,18 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                                 width={100} />
                             <Column
                                 label='File ID'
-                                dataKey='fileT'
-                                width={100} 
-                                cellRenderer={({rowData}) =>(
-                                    rowData.id)} />
+                                dataKey='id'
+                                width={100} />
                             <Column
                                 label='File created at'
                                 dataKey='file'
                                 width={200}
-                                cellRenderer={({rowData}) =>(
-                                    <Time time={rowData.createdAt} /> )} />
-                        </VTable> 
-                    )}      
-                </AutoSizer>  
+                                cellRenderer={({ rowData }) => (
+                                    <Time time={rowData.createdAt} />)} />
+                        </VTable>
+                    )}
+                </AutoSizer>
+
             </div>
         )
     }

--- a/src/components/DropUpload.tsx
+++ b/src/components/DropUpload.tsx
@@ -144,7 +144,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
         this.setState({
             matches: this.state.matches.concat(newMatches),
             uploadedFiles: this.state.uploadedFiles.map(f => ({ ...f, matched: f.matched || matchedIds.indexOf(f.id) > -1 }))
-        })  
+        })
     }
 
     public updateFile(id: string, file: Partial<IUploadedFile<any>>) {
@@ -172,7 +172,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
     public onDrop(accepted: File[], rejected: File[], event: React.DragEvent<HTMLDivElement>) {
         this.setState({
             dragActive: false,
-            isLoading: true
+            // isLoading: true
         })
         const uploadedFiles: Array<IUploadedFile<AudioFileInformation | TranscriptionInformation | undefined>> = [];
         for (const file of accepted) {
@@ -197,9 +197,10 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                         audioFile: file
                     }
                     api.audioPost(requestData).then(res => {
+                        // this.setState({ isLoading: true })
                         this.updateFile(id, { state: RequestState.COMPLETE, fileT: res })
-                        console.log("audio id: ", res.id)
-                        // console.log("audiofileid: ", res.fileInfo.id)
+                        console.log("audio displayid: ", res.id)
+                        res.fileInfo ? console.log("audiofileid: ", res.fileInfo.id) : console.log('cant find fileinfo')
                         console.log("successfully uploaded", file)
                     }).catch(err => {
                         this.updateFile(id, { state: RequestState.FAILED })
@@ -219,9 +220,10 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                         transcriptionFile: file
                     }
                     api.persephoneApiApiEndpointsTranscriptionFromFile(requestData).then(res => {
+                        // this.setState({ isLoading: true })
                         this.updateFile(id, { state: RequestState.COMPLETE, fileT: res })
-                        console.log("transcription id", res.id)
-                        // console.log("transcriptionfile id", res.fileInfo.id)
+                        console.log("transcription displayid", res.id)
+                        res.fileInfo ? console.log("transcriptionfile id", res.fileInfo.id) : console.log('cant find fileinfo')
                         console.log("successfully uploaded", file)
                     }).catch(err => {
                         this.updateFile(id, { state: RequestState.FAILED })
@@ -244,7 +246,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
             }
         }
         this.setState({
-            isLoading: false,
+            // isLoading: false,
             uploadedFiles: this.state.uploadedFiles.concat(uploadedFiles)
         })
         console.log('matches', this.state.matches)
@@ -258,7 +260,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
     noRowsRenderer() {
         return (
             <div>
-                This table is empty
+                No uploaded files
           </div>
         )
     }
@@ -280,11 +282,12 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                 <Header as='h2'>Uploaded files</Header>
                 {this.state.uploadedFiles.length > 0 &&
                     <p>{this.state.uploadedFiles.filter(f => f.fileType === 'Audio').length} audios found, {this.state.uploadedFiles.filter(f => f.fileType === 'Transcription').length} transcriptions found, {this.state.uploadedFiles.filter(f => f.matched === true).length / 2} matches found, {this.state.uploadedFiles.filter(f => f.fileType === 'Unknown').length} unknown files have not been uploaded</p>}
+                <Header as='h3'>Matched files</Header>
                 <AutoSizer disableHeight={true}>
                     {({ width }) => (
                         <VTable
                             headerHeight={30}
-                            height={250}
+                            height={200}
                             noRowsRenderer={this.noRowsRenderer}
                             rowCount={this.state.matches.length}
                             rowGetter={({ index }) => this.state.matches[index]}
@@ -306,7 +309,7 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                                 dataKey='audio | transcription'
                                 width={100}
                                 cellRenderer={({ rowData }) => (
-                                    rowData.fileType
+                                    rowData.audio.fileT ? rowData.audio.fileT.fileType : 'finding filetype'
                                 )} />
                             <Column
                                 label='Upload state'
@@ -317,37 +320,38 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                                 dataKey='audio'
                                 width={300}
                                 cellRenderer={({ rowData }) => (
-                                    rowData.name
+                                    rowData.audio.fileT ? rowData.audio.name : 'finding filename'
                                 )} />
                             <Column
                                 label='ID'
                                 dataKey='audio'
                                 width={100}
                                 cellRenderer={({ rowData }) => (
-                                    rowData.fileT.id
+                                    rowData.audio.fileT ? rowData.audio.fileT.id : 'finding id'
                                 )} />
                             <Column
                                 label='File ID'
                                 dataKey='audio'
                                 width={100}
                                 cellRenderer={({ rowData }) => (
-                                    rowData.fileT.fileInfo.id
+                                    rowData.audio.fileT ? rowData.audio.fileT.fileInfo!.id : 'finding fileid'
                                 )} />
                             <Column
                                 label='File created at'
                                 dataKey='audio'
                                 width={200}
                                 cellRenderer={({ rowData }) => (
-                                    <Time time={rowData.fileT.fileInfo.createdAt} />
+                                    rowData.audio.fileT ? <Time time={rowData.audio.fileT.fileInfo.createdAt} /> : 'finding date'
                                 )} />
                         </VTable>
                     )}
                 </AutoSizer>
+                <Header as='h3'>All files</Header>
                 <AutoSizer disableHeight={true}>
                     {({ width }) => (
                         <VTable
                             headerHeight={30}
-                            height={250}
+                            height={200}
                             noRowsRenderer={this.noRowsRenderer}
                             rowCount={this.state.uploadedFiles.length}
                             rowGetter={({ index }) => this.state.uploadedFiles[index]}
@@ -386,7 +390,8 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                                 dataKey='file'
                                 width={200}
                                 cellRenderer={({ rowData }) => (
-                                    <Time time={rowData.createdAt} />)} />
+                                    <Time time={rowData.createdAt} />
+                                )} />
                         </VTable>
                     )}
                 </AutoSizer>

--- a/src/components/DropUpload.tsx
+++ b/src/components/DropUpload.tsx
@@ -306,10 +306,10 @@ class DropUpload extends React.Component<any, IDropUploadState> {
                                 )} />
                             <Column
                                 label='Type'
-                                dataKey='audio | transcription'
+                                dataKey='audio'
                                 width={100}
                                 cellRenderer={({ rowData }) => (
-                                    rowData.audio.fileT ? rowData.audio.fileT.fileType : 'finding filetype'
+                                    rowData.audio ? rowData.audio.fileType : 'finding filetype'
                                 )} />
                             <Column
                                 label='Upload state'


### PR DESCRIPTION
This is a draft for testing [react-virtualized](https://github.com/bvaughn/react-virtualized) Table in place of the existing table in DropUpload to help the performance issue #59.

This uses a [windowing technique](https://reactjs.org/docs/optimizing-performance.html#virtualize-long-lists) to only render a small subset of data, rather than all the elements at once.

At the moment I'm getting the uploaded files data to display correctly in the table. From a UI perspective it might be a good idea to show a table with all the uploaded files to show the user what has and hasn't been uploaded as well as a table to show all the found matched audio and transcription files.

After getting the data to display correctly I aim to add some sorting to the columns.